### PR TITLE
Custom timestamps for cache entries and TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Eventhub is configured through [environment variables](https://en.wikipedia.org/
 |PING_INTERVAL                | Websocket ping interval             | 30
 |WEBSOCKET_HANDSHAKE_TIMEOUT  | Client handshake timeout            | 15
 |DISABLE_AUTH                 | Disable client authentication       | false
+|PROMETHEUS_METRIC_PREFIX     | Prometheus prefix                   | eventhub
+|DEFAULT_CACHE_TTL            | Default message TTL                 | 60
+|MAX_CACHE_REQUEST_LIMIT      | Default returned cache result limit | 1000
 
 ## Docker
 The easiest way is to use our docker image.

--- a/docs/redis-data-layout.md
+++ b/docs/redis-data-layout.md
@@ -1,0 +1,15 @@
+# Redis layout
+
+**Unique ID**
+
+Each cache item has a separate unique ID that is generated using
+```HINCRBY PREFIX:topicName:cache _idCnt 1```
+
+**Timestamp index**
+
+Each cache-entry is indexed in a sorted set using the messages timestamp as score.
+```ZSET PREFIX:topicName:scores timestamp data=MessageID```
+
+**Storage**
+
+Each cache entry is stored in a hash using ```HSET PREFIX:topicName:cache MessageID Data```

--- a/docs/redis-data-layout.md
+++ b/docs/redis-data-layout.md
@@ -8,7 +8,7 @@ Each cache item has a separate unique ID that is generated using
 **Timestamp index**
 
 Each cache-entry is indexed in a sorted set using the messages timestamp as score.
-```ZSET PREFIX:topicName:scores timestamp data=MessageID```
+```ZSET PREFIX:topicName:scores timestamp MessageID```
 
 **Storage**
 

--- a/include/Common.hpp
+++ b/include/Common.hpp
@@ -30,4 +30,7 @@ static constexpr size_t WS_MAX_CONTROL_FRAME_SIZE = 1024;
 // Delay metric sample rate.
 static constexpr unsigned int METRIC_DELAY_SAMPLE_RATE_MS = 5000;
 
+// Cache purger interval.
+static constexpr unsigned int CACHE_PURGER_INTERVAL_MS = (60 * 1000);
+
 #endif // INCLUDE_COMMON_HPP_

--- a/include/Redis.hpp
+++ b/include/Redis.hpp
@@ -19,6 +19,7 @@ using RedisMsgCallback = std::function<void(std::string pattern,
                                             std::string msg)>;
 
 class Redis {
+#define CONST_24HRS_MS (86400 * 1000)
 #define REDIS_PREFIX(key) std::string((_prefix.length() > 0) ? _prefix + ":" + key : key)
 #define REDIS_CACHE_SCORE_PATH(key) std::string(REDIS_PREFIX(key) + ":scores")
 #define REDIS_CACHE_DATA_PATH(key) std::string(REDIS_PREFIX(key) + ":cache")
@@ -29,8 +30,9 @@ public:
 
   void publishMessage(const string topic, const string id, const string payload);
   void psubscribe(const std::string pattern, RedisMsgCallback callback);
-  const std::string cacheMessage(const string topic, const string payload, double timestamp=0);
-  size_t getCache(const string topicPattern, const string since, size_t limit, bool isPattern, nlohmann::json& result);
+  const std::string cacheMessage(const string topic, const string payload, long long timestamp=0, unsigned int ttl=0);
+  size_t getCache(const string topicPattern, long long since, long long limit, bool isPattern, nlohmann::json& result);
+  size_t purgeExpiredCacheItems();
   void consume();
   void resetSubscribers();
 
@@ -43,7 +45,8 @@ private:
   std::mutex _publish_mtx;
   void _incrTopicPubCount(const string& topicName);
   vector<string> _getTopicsSeen(const string& topicPattern);
-  long long _getNextCacheId(const std::string topic);
+  const std::string _getNextCacheId(const std::string topic);
+  const std::pair<std::string, int64_t> _parseIdAndExpireAt(const std::string& input);
 };
 
 } // namespace eventhub

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -9,6 +9,7 @@
 #include "Redis.hpp"
 #include "Worker.hpp"
 #include "metrics/Types.hpp"
+#include "EventLoop.hpp"
 
 using namespace std;
 
@@ -34,6 +35,7 @@ private:
   std::mutex _connection_workers_lock;
   Redis _redis;
   metrics::ServerMetrics _metrics;
+  EventLoop _ev;
 };
 
 } // namespace eventhub

--- a/src/RPCHandler.cpp
+++ b/src/RPCHandler.cpp
@@ -8,6 +8,7 @@
 #include "TopicManager.hpp"
 #include "Util.hpp"
 #include "websocket/Response.hpp"
+#include "Config.hpp"
 
 #include <sstream>
 #include <stdexcept>
@@ -65,14 +66,27 @@ void RPCHandler::_handleSubscribe(HandlerContext& ctx, jsonrpcpp::request_ptr re
   auto& accessController = ctx.connection()->getAccessController();
   auto params            = req->params();
   std::string topicName;
-  std::string sinceEvent;
+  unsigned long long sinceEvent, limit;
   std::stringstream msg;
 
   try {
     topicName = params.get("topic").get<std::string>();
-    // TODO: Do some sinceEvent validation. Should only contain [0-9\-]+.
-    sinceEvent = params.get("sinceEvent").get<std::string>();
+  } catch (...) {}
+
+  try {
+    sinceEvent = params.get("sinceEvent").get<long long>();
   } catch (...) {
+    sinceEvent = 0;
+  }
+
+  try {
+    limit = params.get("limit").get<long long>();
+  } catch (...) {
+    limit = Config.getInt("MAX_CACHE_REQUEST_LIMIT");
+  }
+
+  if (limit > (unsigned long long)Config.getInt("MAX_CACHE_REQUEST_LIMIT")) {
+    limit = Config.getInt("MAX_CACHE_REQUEST_LIMIT");
   }
 
   if (topicName.empty()) {
@@ -102,12 +116,12 @@ void RPCHandler::_handleSubscribe(HandlerContext& ctx, jsonrpcpp::request_ptr re
   _sendSuccessResponse(ctx, req, result);
 
   // Send cached events if sinceEvent is set.
-  if (!sinceEvent.empty()) {
+  if (sinceEvent > 0) {
     try {
       nlohmann::json result;
       auto& redis      = ctx.server()->getRedis();
 
-      redis.getCache(topicName, sinceEvent, 0, TopicManager::isValidTopicFilter(topicName), result);
+      redis.getCache(topicName, sinceEvent, limit, TopicManager::isValidTopicFilter(topicName), result);
       for (auto& cacheItem : result) {
         _sendSuccessResponse(ctx, req, cacheItem);
       }
@@ -172,6 +186,8 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
   std::string topicName;
   std::string message;
   std::stringstream msg;
+  long long timestamp;
+  unsigned int ttl;
 
   auto& accessController = ctx.connection()->getAccessController();
   auto params            = req->params();
@@ -200,8 +216,20 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
   }
 
   try {
+    timestamp = params.get("timestamp").get<long long>();
+  } catch (...) {
+    timestamp = 0;
+  }
+
+  try {
+    ttl       = params.get("ttl").get<unsigned int>();
+  } catch (...) {
+    ttl = 0;
+  }
+
+  try {
     auto& redis = ctx.server()->getRedis();
-    auto id     = redis.cacheMessage(topicName, message);
+    auto id     = redis.cacheMessage(topicName, message, timestamp, ttl);
 
     if (id.length() == 0) {
       msg << "Failed to cache message to Redis, discarding.";

--- a/src/RPCHandler.cpp
+++ b/src/RPCHandler.cpp
@@ -66,7 +66,7 @@ void RPCHandler::_handleSubscribe(HandlerContext& ctx, jsonrpcpp::request_ptr re
   auto& accessController = ctx.connection()->getAccessController();
   auto params            = req->params();
   std::string topicName;
-  unsigned long long sinceEvent, limit;
+  unsigned long long since, limit;
   std::stringstream msg;
 
   try {
@@ -74,9 +74,9 @@ void RPCHandler::_handleSubscribe(HandlerContext& ctx, jsonrpcpp::request_ptr re
   } catch (...) {}
 
   try {
-    sinceEvent = params.get("sinceEvent").get<long long>();
+    since = params.get("since").get<long long>();
   } catch (...) {
-    sinceEvent = 0;
+    since = 0;
   }
 
   try {
@@ -115,13 +115,13 @@ void RPCHandler::_handleSubscribe(HandlerContext& ctx, jsonrpcpp::request_ptr re
 
   _sendSuccessResponse(ctx, req, result);
 
-  // Send cached events if sinceEvent is set.
-  if (sinceEvent > 0) {
+  // Send cached events if since is set.
+  if (since > 0) {
     try {
       nlohmann::json result;
       auto& redis      = ctx.server()->getRedis();
 
-      redis.getCache(topicName, sinceEvent, limit, TopicManager::isValidTopicFilter(topicName), result);
+      redis.getCache(topicName, since, limit, TopicManager::isValidTopicFilter(topicName), result);
       for (auto& cacheItem : result) {
         _sendSuccessResponse(ctx, req, cacheItem);
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,8 @@ int main(int argc, char** argv) {
     eventhub::Config.addInt("MAX_CACHE_LENGTH", 1000);
     eventhub::Config.addInt("PING_INTERVAL", 30);
     eventhub::Config.addInt("WEBSOCKET_HANDSHAKE_TIMEOUT", 15);
+    eventhub::Config.addInt("DEFAULT_CACHE_TTL", 60);
+    eventhub::Config.addInt("MAX_CACHE_REQUEST_LIMIT", 1000);
     eventhub::Config.addBool("DISABLE_AUTH", false);
     eventhub::Config.addString("PROMETHEUS_METRIC_PREFIX", "eventhub");
   } catch (std::exception& e) {


### PR DESCRIPTION
This PR adds support for specifying a custom timestamp on published events. This is useful for backfilling the cache.

It's also adds TTL for the cache entries.