### PR TITLE
Monitor SSL certificate and private key files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update && \
 
 RUN mkdir -p /usr/src/redis-plus-plus && cd /usr/src/redis-plus-plus && \
     git clone https://github.com/sewenew/redis-plus-plus.git . && \
-    git checkout tags/1.1.2 && \
+    git checkout tags/1.1.1 && \
     mkdir compile && cd compile && cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. && \
     ninja -j0 && ninja install
 

--- a/example.conf
+++ b/example.conf
@@ -30,3 +30,6 @@ enable_sse                  = false
 enable_ssl                  = false
 ssl_certificate             = /etc/eventhub/ssl/certificate.pem
 ssl_private_key             = /etc/eventhub/ssl/key.pem
+
+ssl_cert_auto_reload        = false
+ssl_cert_check_interval     = 10

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -42,6 +42,8 @@ private:
   int _server_socket;
   bool _ssl_enabled;
   SSL_CTX* _ssl_ctx;
+  std::string _ssl_cert_md5_hash;
+  std:: string _ssl_priv_key_md5_hash;
   WorkerGroup<Worker> _connection_workers;
   WorkerGroup<Worker>::iterator _cur_worker;
   std::mutex _connection_workers_lock;
@@ -51,6 +53,7 @@ private:
 
   void _initSSLContext();
   void _loadSSLCertificates();
+  void _checkSSLCertChanged();
 };
 
 } // namespace eventhub

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -53,7 +53,7 @@ private:
 
   void _initSSLContext();
   void _loadSSLCertificates();
-  void _checkSSLCertChanged();
+  void _checkSSLCertUpdated();
 };
 
 } // namespace eventhub

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -13,6 +13,7 @@ public:
   static std::string& strToLower(std::string& s);
   static int64_t getTimeSinceEpoch();
   static std::string getSSLErrorString(unsigned long e);
+  static std::string getFileMD5Sum(const std::string& filePath);
 
 private:
   Util() {}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -293,7 +293,7 @@ void Server::_checkSSLCertUpdated() {
     bool reload = false;
 
     if (ssl_cert_md5_hash != _ssl_cert_md5_hash) {
-      LOG->info("Certificate file " + config().get<std::string>("ssl_certificate") + " change detected.");
+      LOG->info("Change to certificate file " + config().get<std::string>("ssl_certificate") + " detected.");
 
       auto fp = fopen(config().get<std::string>("ssl_certificate").c_str(), "r");
       if (fp) {
@@ -310,7 +310,7 @@ void Server::_checkSSLCertUpdated() {
     }
 
     if (ssl_priv_key_md5_hash != _ssl_priv_key_md5_hash) {
-      LOG->info("TLS key file " + config().get<std::string>("ssl_private_key") + " change detected.");
+      LOG->info("Change to private key file " + config().get<std::string>("ssl_private_key") + " detected.");
       auto fp = fopen(config().get<std::string>("ssl_private_key").c_str(), "r");
       if (fp) {
         PEM_read_PrivateKey(fp, NULL, NULL, NULL);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -168,9 +168,10 @@ void Server::start() {
       },
       true);
 
-  if (isSSL()) {
-    _ev.addTimer(10000, [&](TimerCtx* ctx) {
-      _checkSSLCertChanged();
+  // Monitor ssl certificate and key for changes on disk and reload if updated.
+  if (isSSL() && config().get<bool>("ssl_cert_auto_reload")) {
+    _ev.addTimer(1000 * config().get<int>("ssl_cert_check_interval"), [&](TimerCtx* ctx) {
+      _checkSSLCertUpdated();
     }, true);
   }
 
@@ -283,7 +284,7 @@ void Server::_loadSSLCertificates() {
   _ssl_priv_key_md5_hash = Util::getFileMD5Sum(key);
 }
 
-void Server::_checkSSLCertChanged() {
+void Server::_checkSSLCertUpdated() {
   assert(isSSL());
 
   try {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -116,7 +116,7 @@ std::string Util::getFileMD5Sum(const std::string& filePath) {
   close(fd);
 
   auto mdLen = BIO_gets(bio, buf, sizeof(buf));
-  for (unsigned int i = 0; i < mdLen; i++) {
+  for (int i = 0; i < mdLen; i++) {
     char hex[3];
     sprintf(hex, "%02x", buf[i] & 0xFF);
     out << hex;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -5,11 +5,16 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #include <algorithm>
 #include <chrono>
 #include <sstream>
 #include <string>
+#include <stdexcept>
 
 #include "Common.hpp"
 
@@ -81,5 +86,44 @@ std::string Util::getSSLErrorString(unsigned long e) {
   ERR_error_string_n(e, buf, 512);
   ERR_clear_error();
   return buf;
+}
+
+std::string Util::getFileMD5Sum(const std::string& filePath) {
+  char buf[EVP_MAX_MD_SIZE] = { '\0' };
+  std::stringstream out;
+
+  auto bio = BIO_new(BIO_s_null());
+  auto sha1 = BIO_new(BIO_f_md());
+  BIO_set_md(sha1, EVP_md5());
+  bio = BIO_push(sha1, bio);
+
+  auto fd = open(filePath.c_str(), O_RDONLY);
+  if (!fd) {
+    throw new std::runtime_error("getFileMD5Sum: no such file");
+  }
+
+  int rdLen = 0;
+
+  for(;;) {
+    rdLen = read(fd, &buf, sizeof(buf));
+
+    if (rdLen > 0)
+      BIO_write(bio, buf, rdLen);
+    else
+      break;
+  }
+
+  close(fd);
+
+  auto mdLen = BIO_gets(bio, buf, sizeof(buf));
+  for (unsigned int i = 0; i < mdLen; i++) {
+    char hex[3];
+    sprintf(hex, "%02x", buf[i] & 0xFF);
+    out << hex;
+  }
+
+  BIO_free_all(bio);
+
+  return out.str();
 }
 } // namespace eventhub

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,10 @@ int main(int argc, char** argv) {
       { "enable_ssl",               ConfigValueType::BOOL,   "false",     ConfigValueSettings::REQUIRED },
       { "ssl_ca_certificate",       ConfigValueType::STRING, "",          ConfigValueSettings::OPTIONAL },
       { "ssl_certificate",          ConfigValueType::STRING, "",          ConfigValueSettings::OPTIONAL },
-      { "ssl_private_key",          ConfigValueType::STRING, "",          ConfigValueSettings::OPTIONAL }
+      { "ssl_private_key",          ConfigValueType::STRING, "",          ConfigValueSettings::OPTIONAL },
+      { "ssl_cert_auto_reload",     ConfigValueType::BOOL,   "false",     ConfigValueSettings::OPTIONAL },
+      { "ssl_cert_check_interval",  ConfigValueType::INT,    "300",       ConfigValueSettings::OPTIONAL }
+
     };
 
   Config cfg(cfgMap);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
   src/EventLoopTest.cpp
   src/RedisTest.cpp
   src/AccessControllerTest.cpp
+  src/UtilTest.cpp
   src/main.cpp
 )
 

--- a/tests/src/UtilTest.cpp
+++ b/tests/src/UtilTest.cpp
@@ -1,0 +1,22 @@
+#include "Util.hpp"
+#include "catch.hpp"
+#include <fstream>
+#include <unistd.h>
+
+namespace eventhub {
+
+TEST_CASE("Util test") {
+  SECTION("Test getFileMD5Sum") {
+    unlink("md5testfile");
+    std::ofstream f;
+    f.open("md5testfile");
+    f << "This is a MD5 string";
+    f.close();
+
+    auto sha1Sum = Util::getFileMD5Sum("md5testfile");
+    unlink("md5testfile");
+    REQUIRE(sha1Sum == "65ee3eeff640758f8c1584a6bb9ff6b4");
+  }
+}
+
+}


### PR DESCRIPTION
Support monitoring of SSL certificate and private key for changes on disk and reload if appropriate.
The intention for implementing this is to support systems like letsencrypt that renews certificates every 3months without having to restart eventhub.