### PR TITLE
Initial rate limit functionality.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build-dbg/*
 eventhub.code-workspace
 tests/integration/clienttest/clienttest
 tests/integration/clienttest/vendor/*
+eventhub.conf

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,40 @@
+# Rate limiting
+
+EventHub allows you to rate limit how many messages a user/token is allowed to publish within a given time period (interval). This is configured by adding ```rlimit``` configuration to the token used by the publisher.
+
+#### Syntax
+```json
+  "sub": "user@domain.com", // Must be present and unique.
+  "write": [ "topic1/#" ],
+  "read": [ "topic1/#" ],
+  "rlimit": [
+    {
+      "topic": "topic1/#", // Topic or pattern to limit.
+      "interval": 10, // Bucket interval.
+      "max": 10 // Max allowed publishes within this interval.
+    }
+  ]
+```
+
+You can have multiple limit configuration under ```rlimit```.
+
+#### Example
+```json
+  "sub": "user@domain.com", // Must be defined and unique for limits to work.
+  "write": [ "topic1/#", "topic2" ],
+  "read": [ "topic1/#", "topic2" ],
+  "rlimit": [
+    {
+      "topic": "topic1/#",
+      "interval": 10,
+      "max": 10
+    },
+    {
+      "topic": "topic2",
+      "interval": 10,
+      "max": 10
+    }
+  ]
+```
+
+In cases where you have multiple limits that matches a given topic, i.e patterns and distinct topic name, the closest match will be used.

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -4,7 +4,7 @@ EventHub allows you to rate limit how many messages a user/token is allowed to p
 
 #### Syntax
 ```json
-  "sub": "user@domain.com", // Must be present and unique.
+  "sub": "user@domain.com", // Must be defined and unique for limits to work.
   "write": [ "topic1/#" ],
   "read": [ "topic1/#" ],
   "rlimit": [
@@ -20,7 +20,7 @@ You can have multiple limit configuration under ```rlimit```.
 
 #### Example
 ```json
-  "sub": "user@domain.com", // Must be defined and unique for limits to work.
+  "sub": "user@domain.com",
   "write": [ "topic1/#", "topic2" ],
   "read": [ "topic1/#", "topic2" ],
   "rlimit": [

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,6 +1,6 @@
 # Rate limiting
 
-EventHub allows you to rate limit how many messages a user/token is allowed to publish within a given time period (interval). This is configured by adding ```rlimit``` configuration to the token used by the publisher.
+Eventhub allows you to rate limit how many messages a user/token is allowed to publish within a given time period (interval). This is configured by adding ```rlimit``` configuration to the token used by the publisher.
 
 #### Syntax
 ```json

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -3,15 +3,15 @@
 Eventhub allows you to rate limit how many messages a user/token is allowed to publish within a given time period (interval). This is configured by adding ```rlimit``` configuration to the token used by the publisher.
 
 #### Syntax
-```json
-  "sub": "user@domain.com", // Must be defined and unique for limits to work.
+```json5
+  "sub": "user@domain.com",      // Must be defined and unique for limits to work.
   "write": [ "topic1/#" ],
   "read": [ "topic1/#" ],
   "rlimit": [
     {
-      "topic": "topic1/#", // Topic or pattern to limit.
-      "interval": 10, // Bucket interval.
-      "max": 10 // Max allowed publishes within this interval.
+      "topic": "topic1/#",        // Topic or pattern to limit.
+      "interval": 10,             // Bucket interval.
+      "max": 10                   // Max allowed publishes within this interval.
     }
   ]
 ```

--- a/include/AccessController.hpp
+++ b/include/AccessController.hpp
@@ -11,11 +11,13 @@
 
 namespace eventhub {
 
-typedef struct {
+struct rlimit_config_t {
   std::string topic;
   unsigned long interval;
   unsigned long max;
-} rlimit_config_t;
+};
+
+typedef struct rlimit_config_t rlimit_config_t;
 
 struct NoRateLimitForTopic : public std::exception {
   const char* what() const throw() {

--- a/include/AccessController.hpp
+++ b/include/AccessController.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <exception>
 
 #include "Forward.hpp"
 #include "EventhubBase.hpp"
@@ -16,13 +17,19 @@ typedef struct {
   unsigned long max;
 } rlimit_config_t;
 
+struct NoRateLimitForTopic : public std::exception {
+  const char* what() const throw() {
+    return "Token has no rate limits defined";
+  }
+};
+
 class RateLimitConfig final {
   private:
     std::vector<rlimit_config_t> _limitConfigs;
 
   public:
     bool loadFromJSON(const nlohmann::json::array_t& config);
-    const rlimit_config_t getRateLimitConfigForTopic(const std::string& topic);
+    const rlimit_config_t getRateLimitForTopic(const std::string& topic);
     bool hasLimits();
 };
 

--- a/include/AccessController.hpp
+++ b/include/AccessController.hpp
@@ -12,8 +12,8 @@ namespace eventhub {
 
 typedef struct {
   std::string topic;
-  long interval;
-  long max;
+  unsigned long interval;
+  unsigned long max;
 } rlimit_config_t;
 
 class RateLimitConfig final {

--- a/include/AccessController.hpp
+++ b/include/AccessController.hpp
@@ -9,6 +9,22 @@
 #include "jwt/jwt.hpp"
 
 namespace eventhub {
+
+class RateLimitConfig final {
+  struct rlimit_config_t {
+    std::string topic;
+    long interval;
+    long max;
+  };
+
+  private:
+    std::vector<rlimit_config_t> _limitConfigs;
+
+  public:
+    bool loadFromJSON(const nlohmann::json::array_t& config);
+    const rlimit_config_t getRateLimitConfigForTopic(const std::string& topic);
+};
+
 class AccessController final : public EventhubBase {
 private:
   bool _token_loaded;
@@ -17,6 +33,7 @@ private:
   jwt::jwt_object _token;
   std::vector<std::string> _publish_acl;
   std::vector<std::string> _subscribe_acl;
+  RateLimitConfig _rlimit;
 
 public:
   AccessController(Config &cfg) :
@@ -28,6 +45,7 @@ public:
   bool allowSubscribe(const std::string& topic);
   bool allowCreateToken(const std::string& path);
   const std::string& subject();
+  RateLimitConfig& getRateLimitConfig() { return _rlimit; };
 };
 
 } // namespace eventhub

--- a/include/AccessController.hpp
+++ b/include/AccessController.hpp
@@ -23,23 +23,10 @@ class RateLimitConfig final {
   public:
     bool loadFromJSON(const nlohmann::json::array_t& config);
     const rlimit_config_t getRateLimitConfigForTopic(const std::string& topic);
-    bool hasLimits() { return _limitConfigs.size() > 0; }
+    bool hasLimits();
 };
 
 class AccessController final : public EventhubBase {
-  class NoACLFilterMatched : public std::exception {
-  public:
-    std::string msg;
-
-    NoACLFilterMatched(const std::string& topic) {
-      msg = "No ACL defined for topic " + topic;
-    }
-
-    const char* what() const throw() {
-      return msg.c_str();
-    }
-  };
-
 private:
   bool _token_loaded;
   std::string _jwt_secret;
@@ -58,7 +45,6 @@ public:
   bool allowPublish(const std::string& topic);
   bool allowSubscribe(const std::string& topic);
   bool allowCreateToken(const std::string& path);
-  const std::string& getFilterForTopic(const std::string& topic);
   const std::string& subject();
   RateLimitConfig& getRateLimitConfig() { return _rlimit; };
 };

--- a/include/AccessController.hpp
+++ b/include/AccessController.hpp
@@ -30,7 +30,6 @@ class RateLimitConfig final {
   public:
     bool loadFromJSON(const nlohmann::json::array_t& config);
     const rlimit_config_t getRateLimitForTopic(const std::string& topic);
-    bool hasLimits();
 };
 
 class AccessController final : public EventhubBase {

--- a/include/Redis.hpp
+++ b/include/Redis.hpp
@@ -14,7 +14,6 @@
 #include "EventhubBase.hpp"
 #include "jwt/json/json.hpp"
 #include "Forward.hpp"
-#include "AccessController.hpp"
 
 namespace eventhub {
 
@@ -65,8 +64,8 @@ public:
   std::vector<std::string> _getTopicsSeen(const std::string& topicPattern);
   const std::string _getNextCacheId(long long timestamp);
 
-  bool isRateLimited(rlimit_config_t& limits, const std::string& subject);
-  void incrementLimitCount(rlimit_config_t& limits, const std::string& subject);
+  bool isRateLimited(const std::string& topic, const std::string& subject, unsigned long interval, unsigned long max);
+  void incrementLimitCount(const std::string& topic, const std::string& subject, unsigned long interval, unsigned long max);
 
 private:
   std::shared_ptr<sw::redis::Redis> _redisInstance;

--- a/include/Redis.hpp
+++ b/include/Redis.hpp
@@ -13,6 +13,8 @@
 
 #include "EventhubBase.hpp"
 #include "jwt/json/json.hpp"
+#include "Forward.hpp"
+#include "AccessController.hpp"
 
 namespace eventhub {
 
@@ -43,6 +45,7 @@ class Redis final : public EventhubBase {
 #define REDIS_PREFIX(key) std::string((_prefix.length() > 0) ? _prefix + ":" + key : key)
 #define REDIS_CACHE_SCORE_PATH(key) std::string(REDIS_PREFIX(key) + ":scores")
 #define REDIS_CACHE_DATA_PATH(key) std::string(REDIS_PREFIX(key) + ":cache")
+#define REDIS_RATELIMIT_PATH(key, subject, topic) std::string(REDIS_PREFIX(key) + ":limits:" + topic + ":" + subject)
 
 public:
   explicit Redis(Config &cfg);
@@ -61,6 +64,9 @@ public:
   void _incrTopicPubCount(const std::string& topicName);
   std::vector<std::string> _getTopicsSeen(const std::string& topicPattern);
   const std::string _getNextCacheId(long long timestamp);
+
+  bool isRateLimited(rlimit_config_t& limits, const std::string& subject);
+  void incrementLimitCount(rlimit_config_t& limits, const std::string& subject);
 
 private:
   std::shared_ptr<sw::redis::Redis> _redisInstance;

--- a/include/Redis.hpp
+++ b/include/Redis.hpp
@@ -45,7 +45,7 @@ class Redis final : public EventhubBase {
 #define REDIS_PREFIX(key) std::string((_prefix.length() > 0) ? _prefix + ":" + key : key)
 #define REDIS_CACHE_SCORE_PATH(key) std::string(REDIS_PREFIX(key) + ":scores")
 #define REDIS_CACHE_DATA_PATH(key) std::string(REDIS_PREFIX(key) + ":cache")
-#define REDIS_RATELIMIT_PATH(key, subject, topic) std::string(REDIS_PREFIX(key) + ":rlimit:" + topic + ":" + subject)
+#define REDIS_RATE_LIMIT_PATH(key, subject, topic) std::string(REDIS_PREFIX(key) + ":rlimit:" + topic + ":" + subject)
 
 public:
   explicit Redis(Config &cfg);

--- a/include/Redis.hpp
+++ b/include/Redis.hpp
@@ -13,7 +13,6 @@
 
 #include "EventhubBase.hpp"
 #include "jwt/json/json.hpp"
-#include "Forward.hpp"
 
 namespace eventhub {
 

--- a/include/Redis.hpp
+++ b/include/Redis.hpp
@@ -63,8 +63,8 @@ public:
   std::vector<std::string> _getTopicsSeen(const std::string& topicPattern);
   const std::string _getNextCacheId(long long timestamp);
 
-  bool isRateLimited(const std::string& topic, const std::string& subject, unsigned long interval, unsigned long max);
-  void incrementLimitCount(const std::string& topic, const std::string& subject, unsigned long interval, unsigned long max);
+  bool isRateLimited(const std::string& topic, const std::string& subject, unsigned long max);
+  void incrementLimitCount(const std::string& topic, const std::string& subject, unsigned long interval);
 
 private:
   std::shared_ptr<sw::redis::Redis> _redisInstance;

--- a/include/Redis.hpp
+++ b/include/Redis.hpp
@@ -45,7 +45,7 @@ class Redis final : public EventhubBase {
 #define REDIS_PREFIX(key) std::string((_prefix.length() > 0) ? _prefix + ":" + key : key)
 #define REDIS_CACHE_SCORE_PATH(key) std::string(REDIS_PREFIX(key) + ":scores")
 #define REDIS_CACHE_DATA_PATH(key) std::string(REDIS_PREFIX(key) + ":cache")
-#define REDIS_RATELIMIT_PATH(key, subject, topic) std::string(REDIS_PREFIX(key) + ":limits:" + topic + ":" + subject)
+#define REDIS_RATELIMIT_PATH(key, subject, topic) std::string(REDIS_PREFIX(key) + ":rlimit:" + topic + ":" + subject)
 
 public:
   explicit Redis(Config &cfg);

--- a/src/AccessController.cpp
+++ b/src/AccessController.cpp
@@ -144,11 +144,6 @@ bool RateLimitConfig::loadFromJSON(const nlohmann::json::array_t& config) {
   return true;
 }
 
-// Returns whether we have any limits defined for this token or not.
-bool RateLimitConfig::hasLimits() {
-  return _limitConfigs.size() > 0;
-}
-
 // Returns limits for given topic if there are any.
 // If no limits is defined we throw NoRateLimitForTopic exception.
 const rlimit_config_t RateLimitConfig::getRateLimitForTopic(const std::string& topic) {
@@ -157,7 +152,7 @@ const rlimit_config_t RateLimitConfig::getRateLimitForTopic(const std::string& t
   size_t matchedPatternLen = 0;
 
   // Exit early if no limits is present in token.
-  if (!hasLimits())
+  if (_limitConfigs.empty())
     throw(NoRateLimitForTopic{});
 
   /*

--- a/src/AccessController.cpp
+++ b/src/AccessController.cpp
@@ -132,8 +132,8 @@ bool RateLimitConfig::loadFromJSON(const nlohmann::json::array_t& config) {
 
     try {
       auto topic = rlimit["topic"].get<std::string>();
-      auto interval = rlimit["interval"].get<long>();
-      auto max = rlimit["max"].get<long>();
+      auto interval = rlimit["interval"].get<unsigned long>();
+      auto max = rlimit["max"].get<unsigned long>();
 
       _limitConfigs.push_back(rlimit_config_t{topic, interval, max});
     } catch (...) {

--- a/src/RPCHandler.cpp
+++ b/src/RPCHandler.cpp
@@ -247,10 +247,10 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
 
   try {
     auto& redis = ctx.server()->getRedis();
+    const auto& subject = accessController->subject();
 
-    if (accessController->getRateLimitConfig().hasLimits()) {
-      auto& subject = accessController->subject();
-      auto limits = accessController->getRateLimitConfig().getRateLimitConfigForTopic(topicName);
+    if (!subject.empty() && accessController->getRateLimitConfig().hasLimits()) {
+      const auto limits = accessController->getRateLimitConfig().getRateLimitConfigForTopic(topicName);
 
       if (redis.isRateLimited(limits.topic, subject, limits.max)) {
         LOG->trace("PUBLISH {}: User {} is currently ratelimited. Interval: {} Max: {} Matched ratelimit pattern: {}", topicName, subject, limits.interval, limits.max, limits.topic);

--- a/src/RPCHandler.cpp
+++ b/src/RPCHandler.cpp
@@ -253,7 +253,7 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
       auto limits = accessController->getRateLimitConfig().getRateLimitConfigForTopic(topicName);
 
       if (redis.isRateLimited(limits.topic, subject, limits.max)) {
-        LOG->trace("PUBLISH {}: User {} is currently ratelimited. Interval: {} Max: {}", topicName, subject, limits.interval, limits.max);
+        LOG->trace("PUBLISH {}: User {} is currently ratelimited. Interval: {} Max: {} Matched ratelimit pattern: {}", topicName, subject, limits.interval, limits.max, limits.topic);
         nlohmann::json result;
         result["action"] = "publish";
         result["topic"]  = topicName;

--- a/src/RPCHandler.cpp
+++ b/src/RPCHandler.cpp
@@ -249,11 +249,10 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
     auto& redis = ctx.server()->getRedis();
 
     if (accessController->getRateLimitConfig().hasLimits()) {
-      //auto& filter = accessController->getFilterForTopic(topicName);
       auto& subject = accessController->subject();
       auto limits = accessController->getRateLimitConfig().getRateLimitConfigForTopic(topicName);
 
-      if (redis.isRateLimited(limits, subject)) {
+      if (redis.isRateLimited(limits.topic, subject, limits.interval, limits.max)) {
         nlohmann::json result;
         result["action"] = "publish";
         result["topic"]  = topicName;
@@ -261,7 +260,7 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
 
         return _sendSuccessResponse(ctx, req, result);
       } else {
-        redis.incrementLimitCount(limits, subject);
+        redis.incrementLimitCount(limits.topic, subject, limits.interval, limits.max);
       }
     }
 

--- a/src/RPCHandler.cpp
+++ b/src/RPCHandler.cpp
@@ -253,6 +253,7 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
       auto limits = accessController->getRateLimitConfig().getRateLimitConfigForTopic(topicName);
 
       if (redis.isRateLimited(limits.topic, subject, limits.max)) {
+        LOG->trace("PUBLISH {}: User {} is currently ratelimited. Interval: {} Max: {}", topicName, subject, limits.interval, limits.max);
         nlohmann::json result;
         result["action"] = "publish";
         result["topic"]  = topicName;

--- a/src/RPCHandler.cpp
+++ b/src/RPCHandler.cpp
@@ -252,7 +252,7 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
       auto& subject = accessController->subject();
       auto limits = accessController->getRateLimitConfig().getRateLimitConfigForTopic(topicName);
 
-      if (redis.isRateLimited(limits.topic, subject, limits.interval, limits.max)) {
+      if (redis.isRateLimited(limits.topic, subject, limits.max)) {
         nlohmann::json result;
         result["action"] = "publish";
         result["topic"]  = topicName;
@@ -260,7 +260,7 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
 
         return _sendSuccessResponse(ctx, req, result);
       } else {
-        redis.incrementLimitCount(limits.topic, subject, limits.interval, limits.max);
+        redis.incrementLimitCount(limits.topic, subject, limits.interval);
       }
     }
 

--- a/src/RPCHandler.cpp
+++ b/src/RPCHandler.cpp
@@ -258,7 +258,7 @@ void RPCHandler::_handlePublish(HandlerContext& ctx, jsonrpcpp::request_ptr req)
           nlohmann::json result;
           result["action"] = "publish";
           result["topic"]  = topicName;
-          result["status"] = "ERR_RATELIMITED";
+          result["status"] = "ERR_RATE_LIMIT_EXCEEDED";
 
           return _sendSuccessResponse(ctx, req, result);
         } else {

--- a/src/Redis.cpp
+++ b/src/Redis.cpp
@@ -403,9 +403,8 @@ std::vector<std::string> Redis::_getTopicsSeen(const std::string& topicPattern) 
   @param topicPattern Topic to check.
 */
 bool Redis::isRateLimited(rlimit_config_t& limits, const std::string& subject) {
-  if (limits.topic.empty() || limits.max == 0 || limits.interval == 0) {
+  if (limits.topic.empty() || limits.max == 0 || limits.interval == 0)
     return false;
-  }
 
   const auto key = REDIS_RATELIMIT_PATH(_prefix, subject, limits.topic);
   auto count = _redisInstance->get(key);

--- a/src/Redis.cpp
+++ b/src/Redis.cpp
@@ -399,16 +399,14 @@ std::vector<std::string> Redis::_getTopicsSeen(const std::string& topicPattern) 
 /*
   Check if a user is ratelimited.
 */
-bool Redis::isRateLimited(const std::string& topic, const std::string& subject, unsigned long interval, unsigned long max) {
-  if (topic.empty() || max == 0 || interval == 0)
+bool Redis::isRateLimited(const std::string& topic, const std::string& subject, unsigned long max) {
+  if (topic.empty() || max == 0)
     return false;
 
   const auto key = REDIS_RATE_LIMIT_PATH(_prefix, subject, topic);
   auto count = _redisInstance->get(key);
   if (count) {
     auto c = std::stoull(count.value(), nullptr, 10);
-    LOG->debug("isRateLimited: Sub: {} count: {} max: {} interval: {} topic: {}",
-      subject, c, max, interval, topic);
     if (c >= max) {
       return true;
     }
@@ -420,8 +418,8 @@ bool Redis::isRateLimited(const std::string& topic, const std::string& subject, 
 /*
   Increment publish count for user.
 */
-void Redis::incrementLimitCount(const std::string& topic, const std::string& subject, unsigned long interval, unsigned long max) {
-  if (topic.empty() || max == 0 || interval == 0)
+void Redis::incrementLimitCount(const std::string& topic, const std::string& subject, unsigned long interval) {
+  if (topic.empty() || interval == 0)
     return;
 
   const auto key = REDIS_RATE_LIMIT_PATH(_prefix, subject, topic);

--- a/src/Redis.cpp
+++ b/src/Redis.cpp
@@ -400,7 +400,7 @@ std::vector<std::string> Redis::_getTopicsSeen(const std::string& topicPattern) 
   Check if a user is ratelimited.
 */
 bool Redis::isRateLimited(const std::string& topic, const std::string& subject, unsigned long max) {
-  if (topic.empty() || max == 0)
+  if (max == 0)
     return false;
 
   const auto key = REDIS_RATE_LIMIT_PATH(_prefix, subject, topic);
@@ -419,7 +419,7 @@ bool Redis::isRateLimited(const std::string& topic, const std::string& subject, 
   Increment publish count for user.
 */
 void Redis::incrementLimitCount(const std::string& topic, const std::string& subject, unsigned long interval) {
-  if (topic.empty() || interval == 0)
+  if (interval == 0)
     return;
 
   const auto key = REDIS_RATE_LIMIT_PATH(_prefix, subject, topic);

--- a/src/Redis.cpp
+++ b/src/Redis.cpp
@@ -406,7 +406,7 @@ bool Redis::isRateLimited(rlimit_config_t& limits, const std::string& subject) {
   if (limits.topic.empty() || limits.max == 0 || limits.interval == 0)
     return false;
 
-  const auto key = REDIS_RATELIMIT_PATH(_prefix, subject, limits.topic);
+  const auto key = REDIS_RATE_LIMIT_PATH(_prefix, subject, limits.topic);
   auto count = _redisInstance->get(key);
   if (count) {
     auto c = std::stoull(count.value(), nullptr, 10);
@@ -429,7 +429,10 @@ void Redis::incrementLimitCount(rlimit_config_t& limits, const std::string& subj
   if (limits.topic.empty() || limits.max == 0 || limits.interval == 0)
     return;
 
-  const auto key = REDIS_RATELIMIT_PATH(_prefix, subject, limits.topic);
+  const auto key = REDIS_RATE_LIMIT_PATH(_prefix, subject, limits.topic);
+
+  // FIXME: We might be able to optimize away this call to get by using the value from the previous get call
+  // in the isRateLimited() function.
   auto count = _redisInstance->get(key);
 
   if (count) {

--- a/tests/src/AccessControllerTest.cpp
+++ b/tests/src/AccessControllerTest.cpp
@@ -134,19 +134,14 @@ TEST_CASE("Test authorization", "[access_controller]") {
 
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1").interval == 10);
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1").max == 10);
-
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1/foo").interval == 10);
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1/foo").max == 10);
-
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1/foo/bar").interval == 10);
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1/foo/bar").max == 10);
-
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic2").interval == 100);
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic2").max == 10);
-
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic2/foo").interval == 0);
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic2/foo").max == 0);
-
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic3").interval == 0);
       REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic3").max == 0);
     }

--- a/tests/src/AccessControllerTest.cpp
+++ b/tests/src/AccessControllerTest.cpp
@@ -119,18 +119,17 @@ TEST_CASE("Test authorization", "[access_controller]") {
 
     THEN("We should have the correct limits set for topics defined in token.") {
       /*
-        Test token:
-          "rlimit": [{
-            "topic": "topic1/#",
-            "interval": 10,
-            "max": 10
-          },
-          {
-            "topic": "topic2",
-            "interval": 100,
-            "max": 10
+        "rlimit": [{
+          "topic": "topic1/#",
+          "interval": 10,
+          "max": 10
+        },
+        {
+          "topic": "topic2",
+          "interval": 100,
+          "max": 10
           }
-    */
+      */
 
       REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic1").interval == 10);
       REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic1").max == 10);
@@ -144,7 +143,6 @@ TEST_CASE("Test authorization", "[access_controller]") {
       CHECK_THROWS_AS(acs.getRateLimitConfig().getRateLimitForTopic("topic2/foo"), NoRateLimitForTopic);
       CHECK_THROWS_AS(acs.getRateLimitConfig().getRateLimitForTopic("topic3"), NoRateLimitForTopic);
       CHECK_THROWS_AS(acs.getRateLimitConfig().getRateLimitForTopic("topic3"), NoRateLimitForTopic);
-
     }
   }
 }

--- a/tests/src/AccessControllerTest.cpp
+++ b/tests/src/AccessControllerTest.cpp
@@ -132,18 +132,19 @@ TEST_CASE("Test authorization", "[access_controller]") {
           }
     */
 
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1").interval == 10);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1").max == 10);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1/foo").interval == 10);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1/foo").max == 10);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1/foo/bar").interval == 10);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic1/foo/bar").max == 10);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic2").interval == 100);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic2").max == 10);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic2/foo").interval == 0);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic2/foo").max == 0);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic3").interval == 0);
-      REQUIRE(acs.getRateLimitConfig().getRateLimitConfigForTopic("topic3").max == 0);
+      REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic1").interval == 10);
+      REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic1").max == 10);
+      REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic1/foo").interval == 10);
+      REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic1/foo").max == 10);
+      REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic1/foo/bar").interval == 10);
+      REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic1/foo/bar").max == 10);
+      REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic2").interval == 100);
+      REQUIRE(acs.getRateLimitConfig().getRateLimitForTopic("topic2").max == 10);
+
+      CHECK_THROWS_AS(acs.getRateLimitConfig().getRateLimitForTopic("topic2/foo"), NoRateLimitForTopic);
+      CHECK_THROWS_AS(acs.getRateLimitConfig().getRateLimitForTopic("topic3"), NoRateLimitForTopic);
+      CHECK_THROWS_AS(acs.getRateLimitConfig().getRateLimitForTopic("topic3"), NoRateLimitForTopic);
+
     }
   }
 }


### PR DESCRIPTION
This PR implements functionality for adding rate limiting to tokens.
This allows us to limit how many messages a user/subject can publish in a given time frame/bucket.

Token format to configure such limits is:
```
{
  "sub": "user@domain.com",
  "read": [
    "nolimit",
    "topic/#",
    "topic2/#"
  ],
  "write": [
    "nolimit",
    "topic1/#",
    "topic2/#"
  ],
  "rlimit": [
    {
      "topic": "topic1/#",
      "interval": 10,
      "max": 10
    },
    {
      "topic": "topic2/#",
      "interval": 30,
      "max": 10
    }
  ]
}
```