### PR TITLE
feat: start returning metric types in Prometheus response

### DIFF
--- a/src/metrics/PrometheusRenderer.cpp
+++ b/src/metrics/PrometheusRenderer.cpp
@@ -17,28 +17,35 @@ const std::string PrometheusRenderer::RenderMetrics(Server* server) {
   auto  metrics = server->getAggregatedMetrics();
   auto& config  = server->config();
 
-  std::vector<std::pair<std::string, long long>> metricList = {
-      {"worker_count", metrics.worker_count},
-      {"publish_count", metrics.publish_count},
-      {"redis_connection_fail_count", metrics.redis_connection_fail_count},
-      {"redis_publish_delay_ms", metrics.redis_publish_delay_ms},
+  std::vector<std::tuple<std::string, std::string, long long>> metricList = {
+      {"worker_count", "gauge", metrics.worker_count},
+      {"publish_count", "counter", metrics.publish_count},
+      {"redis_connection_fail_count", "counter", metrics.redis_connection_fail_count},
+      {"redis_publish_delay_ms", "histogram", metrics.redis_publish_delay_ms},
 
-      {"current_connections_count", metrics.current_connections_count},
-      {"total_connect_count", metrics.total_connect_count},
-      {"total_disconnect_count", metrics.total_disconnect_count},
-      {"eventloop_delay_ms", metrics.eventloop_delay_ms}};
+      {"current_connections_count", "gauge", metrics.current_connections_count},
+      {"total_connect_count", "counter", metrics.total_connect_count},
+      {"total_disconnect_count", "counter", metrics.total_disconnect_count},
+      {"eventloop_delay_ms", "histogram", metrics.eventloop_delay_ms}};
 
   char h_buf[128] = {0};
   std::stringstream ss;
 
   gethostname(h_buf, sizeof(h_buf));
 
-  for (auto& m : metricList) {
+  for (const auto& metric : metricList) {
+    const std::string& metricName = std::get<0>(metric);
+    const std::string& metricType = std::get<1>(metric);
+    const long long& metricValue   = std::get<2>(metric);
+
+    // Output the type of each metric
+    ss << "# TYPE " << metricName << " " << metricType << "\n";
+
     // Add prefix to metric key if set in configuration.
-    const std::string metricKey = !config.get<std::string>("prometheus_metric_prefix").empty() ? (config.get<std::string>("prometheus_metric_prefix") + "_" + m.first) : m.first;
+    const std::string metricKey = !config.get<std::string>("prometheus_metric_prefix").empty() ? (config.get<std::string>("prometheus_metric_prefix") + "_" + metricName) : metricName;
 
     ss << metricKey << "{instance=\"" << h_buf << ":" << config.get<int>("listen_port") << "\""
-       << "} " << m.second << "\n";
+       << "} " << metricValue << "\n";
   }
 
   return ss.str();


### PR DESCRIPTION
# Why

It's good to have a default metric type assigned for each metric

Following [Prometheus docs](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-format-example) 

metric types described [here](https://prometheus.io/docs/concepts/metric_types/)

# What

I hope I selected a correct type of each metric

Tested locally
```
# TYPE worker_count gauge
eventhub_worker_count{instance="c7af11ba1974:8080"} 2
# TYPE publish_count counter
eventhub_publish_count{instance="c7af11ba1974:8080"} 0
# TYPE redis_connection_fail_count counter
eventhub_redis_connection_fail_count{instance="c7af11ba1974:8080"} 0
# TYPE redis_publish_delay_ms histogram
eventhub_redis_publish_delay_ms{instance="c7af11ba1974:8080"} 0
# TYPE current_connections_count gauge
eventhub_current_connections_count{instance="c7af11ba1974:8080"} 1
# TYPE total_connect_count counter
eventhub_total_connect_count{instance="c7af11ba1974:8080"} 16
# TYPE total_disconnect_count counter
eventhub_total_disconnect_count{instance="c7af11ba1974:8080"} 15
# TYPE eventloop_delay_ms histogram
eventhub_eventloop_delay_ms{instance="c7af11ba1974:8080"} 1
```