### PR TITLE
fix: use prefixed metric in the #TYPE statement

### DIFF
--- a/src/metrics/PrometheusRenderer.cpp
+++ b/src/metrics/PrometheusRenderer.cpp
@@ -34,17 +34,15 @@ const std::string PrometheusRenderer::RenderMetrics(Server* server) {
   gethostname(h_buf, sizeof(h_buf));
 
   for (const auto& metric : metricList) {
-    const std::string& metricName = std::get<0>(metric);
+    // Add prefix provided in configuration to metric name
+    const std::string& metricName = config.get<std::string>("prometheus_metric_prefix") + "_" + std::get<0>(metric);
     const std::string& metricType = std::get<1>(metric);
     const long long& metricValue   = std::get<2>(metric);
 
-    // Add prefix to metric key if set in configuration.
-    const std::string metricKey = !config.get<std::string>("prometheus_metric_prefix").empty() ? (config.get<std::string>("prometheus_metric_prefix") + "_" + metricName) : metricName;
-
     // Output the type of each metric
-    ss << "# TYPE " << metricKey << " " << metricType << "\n";
+    ss << "# TYPE " << metricName << " " << metricType << "\n";
 
-    ss << metricKey << "{instance=\"" << h_buf << ":" << config.get<int>("listen_port") << "\""
+    ss << metricName << "{instance=\"" << h_buf << ":" << config.get<int>("listen_port") << "\""
        << "} " << metricValue << "\n";
   }
 

--- a/src/metrics/PrometheusRenderer.cpp
+++ b/src/metrics/PrometheusRenderer.cpp
@@ -38,11 +38,11 @@ const std::string PrometheusRenderer::RenderMetrics(Server* server) {
     const std::string& metricType = std::get<1>(metric);
     const long long& metricValue   = std::get<2>(metric);
 
-    // Output the type of each metric
-    ss << "# TYPE " << metricName << " " << metricType << "\n";
-
     // Add prefix to metric key if set in configuration.
     const std::string metricKey = !config.get<std::string>("prometheus_metric_prefix").empty() ? (config.get<std::string>("prometheus_metric_prefix") + "_" + metricName) : metricName;
+
+    // Output the type of each metric
+    ss << "# TYPE " << metricKey << " " << metricType << "\n";
 
     ss << metricKey << "{instance=\"" << h_buf << ":" << config.get<int>("listen_port") << "\""
        << "} " << metricValue << "\n";


### PR DESCRIPTION
# Why

Because #48 used non-prefixed metric name while metric prefix is always defined (it's set to `eventhub` as default)


locally tested with `PROMETHEUS_METRIC_PREFIX=eventhub-local`
```
# TYPE eventhub-local_worker_count gauge
eventhub-local_worker_count{instance="22ff7fdc9522:8080"} 2
# TYPE eventhub-local_publish_count counter
eventhub-local_publish_count{instance="22ff7fdc9522:8080"} 0
# TYPE eventhub-local_redis_connection_fail_count counter
eventhub-local_redis_connection_fail_count{instance="22ff7fdc9522:8080"} 0
# TYPE eventhub-local_redis_publish_delay_ms histogram
eventhub-local_redis_publish_delay_ms{instance="22ff7fdc9522:8080"} 0
# TYPE eventhub-local_current_connections_count gauge
eventhub-local_current_connections_count{instance="22ff7fdc9522:8080"} 2
# TYPE eventhub-local_total_connect_count counter
eventhub-local_total_connect_count{instance="22ff7fdc9522:8080"} 4
# TYPE eventhub-local_total_disconnect_count counter
eventhub-local_total_disconnect_count{instance="22ff7fdc9522:8080"} 2
# TYPE eventhub-local_eventloop_delay_ms histogram
eventhub-local_eventloop_delay_ms{instance="22ff7fdc9522:8080"} 1
```